### PR TITLE
Export logger types

### DIFF
--- a/packages/client/src/links/loggerLink.ts
+++ b/packages/client/src/links/loggerLink.ts
@@ -20,7 +20,7 @@ type EnabledFn<TRouter extends AnyRouter> = (
   opts: EnableFnOptions<TRouter>,
 ) => boolean;
 
-type LogFnOptions<TRouter extends AnyRouter> = Operation &
+export type LogFnOptions<TRouter extends AnyRouter> = Operation &
   (
     | {
         /**
@@ -37,7 +37,7 @@ type LogFnOptions<TRouter extends AnyRouter> = Operation &
         elapsedMs: number;
       }
   );
-type LogFn<TRouter extends AnyRouter> = (opts: LogFnOptions<TRouter>) => void;
+export type LogFn<TRouter extends AnyRouter> = (opts: LogFnOptions<TRouter>) => void;
 
 const palette = {
   query: ['72e3ff', '3fb0d8'],


### PR DESCRIPTION
This allows a user to override `logger` easily in `loggerLink`

Closes #2898

## 🎯 Changes

What changes are made in this PR? Is it a feature or a bug fix?

## ✅ Checklist

- [x] I have followed the steps listed in the [Contributing guide](https://github.com/trpc/trpc/blob/main/CONTRIBUTING.md).
- [] If necessary, I have added documentation related to the changes made. **not sure if this needs it?**
- [x] I have added or updated the tests related to the changes made.